### PR TITLE
Feedback

### DIFF
--- a/feedback/defensive-colmeans-sol.Rmd
+++ b/feedback/defensive-colmeans-sol.Rmd
@@ -1,0 +1,65 @@
+```{r, child = "defensive-colmeans-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+
+Minimalstlösung:
+```{r, col_means_def_1}
+# compute means of all numeric columns in <data>
+# input: a data.frame 
+# output: a data.frame containing the column means
+col_means <- function(data) {
+  stopifnot(is.data.frame(data), all(dim(data)) > 0)
+
+  numeric <- sapply(data, is.numeric)
+  data_numeric <- data[, numeric, drop = FALSE]
+
+  data.frame(vapply(data_numeric, mean, numeric(1)))
+}
+```
+```{r, col_means_test, error = TRUE}
+```
+
+Etwas ausgefeilter:
+```{r, col_means_def_2}
+# compute means of all columns in data for whose class "mean" is defined
+# data: anything that can be converted to a data.frame
+# na.rm: drop NAs?
+# output: a data.frame containing the column means of all numeric columns
+col_means <- function(data, na.rm = FALSE) {
+  checkmate::assert_flag(na.rm)
+  if (!is.data.frame(data)) {
+    data <- try(as.data.frame(data))
+    if (inherits(data, "try-error")) {
+      stop("<data> not convertable to a data.frame")
+    } else {
+      message("<data> converted to data.frame.")
+    }
+  }
+
+  # selecting columns for which mean can be computed:
+  use <- vapply(data, has_mean, logical(1))
+  # drop = FALSE so single columns work as expected!
+  data_numeric <- data[, use, drop = FALSE]
+  
+  # check for zero dims *after* selecting columns so all-character
+  # and all-factor data.frames get picked up as well.
+  if (any(dim(data_numeric) == 0)) {
+    warning("<data> does not contain entries for which means can be computed.")
+    return(data.frame())
+  }
+  as.data.frame(lapply(data_numeric, mean, na.rm = na.rm))
+}
+
+# see methods("mean") for datatypes with mean()-method
+has_mean <- function(x) {
+  is.numeric(x) |
+    inherits(x, what = c("Date", "POSIXct", "POSIXlt", "difftime"))
+}
+
+```
+```{r, col_means_test, error=TRUE}
+```

--- a/feedback/defensive-count-sol.Rmd
+++ b/feedback/defensive-count-sol.Rmd
@@ -1,0 +1,66 @@
+```{r, child = "defensive-count-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a)  
+
+Implizite Annahmen über `supposedly_a_count` von denen abhängt ob der 
+ursprünglichen Code das erwartete Verhalten hat:
+
+- `supposedly_a_count` ist was numerisches
+- `supposedly_a_count` hat Länge 1
+- `supposedly_a_count` ist nicht `NA` oder `NaN`
+- `supposedly_a_count` ist nicht negativ
+- `supposedly_a_count` ist nicht unendlich
+
+
+b)  
+
+Strenge Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  checkmate::assert_number(supposedly_a_count,
+                           lower = 0, finite = TRUE,
+                           null.ok = FALSE, na.ok = FALSE
+  ) # defaults, not necessary
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest integer."
+    )
+    supposedly_a_count <- round(supposedly_a_count)
+  }
+  #always return an integer:
+  as.integer(supposedly_a_count)
+}  
+```
+
+Nachsichtigere Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  if (length(supposedly_a_count) > 1) {
+    warning("only using first element of supposedly_a_count")
+    supposedly_a_count <- supposedly_a_count[1]
+  }
+  checkmate::assert_number(supposedly_a_count, finite = TRUE)
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest non-negative integer."
+    )
+    as.integer(max(0, round(supposedly_a_count)))
+  }
+}
+```
+
+Zu pragmatische Variante (ohne Warnungen, und die erste Zeile könnte schiefgehen...):
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  supposedly_a_count <- round(as.numeric(supposedly_a_count[1]))
+  checkmate::assert_count(supposedly_a_count)
+  as.integer(supposedly_a_count)
+}  
+```

--- a/feedback/defensive-lag-sol.Rmd
+++ b/feedback/defensive-lag-sol.Rmd
@@ -1,0 +1,35 @@
+```{r, child = "defensive-lag-ex.Rmd"}
+```
+
+----------------------------------------------------
+### Lösung:
+
+Zum Beispiel:
+```{r, lag-def}
+# make a lagged version of x
+# inputs: x: a vector
+#         lag: how many lags?
+lag <- function(x, lag = 1L) {
+  checkmate::assert_atomic_vector(x, min.len = 1)
+  checkmate::assert_count(lag)
+  checkmate::assert_number(lag, upper = length(x))
+  c(rep(NA, lag), x[seq_len(length(x) - lag)])
+}
+```
+```{r, lag-test, error=TRUE}
+x <- seq_len(10)
+
+testthat::expect_equal(lag(x, 2), c(NA, NA, x[1:8]))
+testthat::expect_equal(lag(x, 0), x)
+testthat::expect_equal(lag(x, 10), rep(NA_integer_, 10))
+
+# these should all give errors that are triggered by input checks:
+testthat::expect_error(lag(list(1, 2)))
+testthat::expect_error(lag(matrix(1:2, 1, 2)))
+testthat::expect_error(lag(data.frame(1, 2)))
+
+testthat::expect_error(lag(x, 11))
+testthat::expect_error(lag(x, -1))
+testthat::expect_error(lag(x, c(1, 3)))
+testthat::expect_error(lag(x, .2))
+```


### PR DESCRIPTION
@alflenpaula 

hmmmm... :thinking:  befriedigt mich nur sehr teilweise --
haben sie davor die folien / videos angeschaut? 

Wir benutzen das `checkmate` Paket für input checks!


*`colmeans`*:

sehr taugliche lösung, aber bitte **input checks** und generell noch defensiver denken...

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-colmeans-ex-sol.Rmd#L13
input checks fehlen -- sie müssen generell überprüfen OB df was data.frame artiges ist (bzw: in einen data.frame umgewandelt werden kann) und OB na.rm ein einzelner logischer Wert ist - vgl Musterlösung
- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-colmeans-ex-sol.Rmd#L26 das kann schiefgehen, also muss es in ein `try` gewickelt werden und entsprechend nachverarbeitet.
- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-colmeans-ex-sol.Rmd#L21 reicht nicht --- auch list-columns zB können nicht gemittelt werden bzw werden in iher zeile 29 entfernt. be more paranoid!
 
- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-colmeans-ex-sol.Rmd#L29 die warnung die sie oben ausgeben falls df leer ist sollte mMn erst hier kommen (falls der datensatz zwar spalten enthält, die aber alle character oder factor sind.....)


*`count_them`*

nee, sorry, hier war die Benutzung von `checkmate::assert_XXX` gefragt....

-  https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-count-ex-sol.Rmd#L9-L17 **KIS!** bitte benutzen sie die `assert_BLA` funktionen aus `checkmate` statt diese sachen so langwierig selber zu implementieren. außerdem fehlt: darf auch nicht NA sein

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-count-ex-sol.Rmd#L15 `class(x)` kann auch ein  ganzer vektor sein und dann gibt das hier eine warnmeldung weil die `if`-Bedingung nur EINEN logischen Wert bekommen sollte: 
```r
> if(c(TRUE, FALSE)) "uh-oh!"
[1] "uh-oh!"
Warning message:
In if (c(TRUE, FALSE)) "uh-oh!" :
  the condition has length > 1 and only the first element will be used
```
deswegen sowas immer besser mit `inherits(x, "numeric")` oder `is.numeric(x)`. 
Hier im Kurs benutzen Sie bitte die `assert_BLA` funktionen aus `checkmate` statt diese sachen so langwierig selber zu implementieren...

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-count-ex-sol.Rmd#L13-L15
sie können nicht mit `supposedly_a_count` numerische vergleiche anstellen (`< 0`, etc) *BEVOR* sie überprüft haben dass das ding überhaupt eine Zahl ist... die Reihenfolge hier ist verkehrt. 
Benutzen Sie bitte die `assert_BLA` funktionen aus `checkmate` statt diese sachen so langwierig  & fehlerträchtig selber zu implementieren.

*`lag`*:

das war nix....

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-lag-ex-sol.Rmd#L7
`test_count(x, n)` macht keinen sinn, nur das erste argument wird geprüft, die anderen argumente modifzieren die testbedingungen....

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-lag-ex-sol.Rmd#L8 auch listen sind `vector` .  `assert_atomic_vector` wäre hier korrekt.

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-lag-ex-sol.Rmd#L16 warum? halte ich für überflüssig.

- https://github.com/fort-w2021/defensive-ex-alflenpaula/blob/8ad1ef64c5838f4ee5d8e2c7860235e68fb9dcbd/SOLUTIONS/defensive-lag-ex-sol.Rmd#L20-L25 nö nö nö -  
1. `x` kann beliebige (auch nicht-numerische) werte enthalten, diese ganzen bedingungen für x sind völlig überflüssig
2.  if`-Bedingung dürfen nur EINEN logischen Wert bekommen, alle diese vergleiuchsoperatoren geben aber logische vektoren der selben länge wie x zurück
